### PR TITLE
set `dllname_img` for every platform

### DIFF
--- a/iup.nim
+++ b/iup.nim
@@ -40,10 +40,10 @@ when defined(windows):
   const dllname_img = "iupimglib(|30|27|26|25|24).dll"
 elif defined(macosx):
   const dllname = "libiup(|3.0|2.7|2.6|2.5|2.4).dylib"
-  const dllname_img = "libiupimglib(|30|27|26|25|24).dylib"
+  const dllname_img = "libiupimglib(|3.0|2.7|2.6|2.5|2.4).dylib"
 else:
   const dllname = "libiup(|3.0|2.7|2.6|2.5|2.4).so(|.1)"
-  const dllname_img = "libiupimglib(|30|27|26|25|24).so(|.1)"
+  const dllname_img = "libiupimglib(|3.0|2.7|2.6|2.5|2.4).so(|.1)"
 
 const
   IUP_NAME* = "IUP - Portable User Interface"

--- a/iup.nim
+++ b/iup.nim
@@ -40,8 +40,10 @@ when defined(windows):
   const dllname_img = "iupimglib(|30|27|26|25|24).dll"
 elif defined(macosx):
   const dllname = "libiup(|3.0|2.7|2.6|2.5|2.4).dylib"
+  const dllname_img = "libiupimglib(|30|27|26|25|24).dylib"
 else:
   const dllname = "libiup(|3.0|2.7|2.6|2.5|2.4).so(|.1)"
+  const dllname_img = "libiupimglib(|30|27|26|25|24).so(|.1)"
 
 const
   IUP_NAME* = "IUP - Portable User Interface"


### PR DESCRIPTION
Set `dllname_img` according to IUP documents.

PR #8 introduced `dllname_img`, but only set it on Windows. On other OS it should be `libiupimglib` in corresponding suffix.